### PR TITLE
[CMS PR 35874] Move custom files in core templates to media folder on update

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -8443,7 +8443,7 @@ class JoomlaInstallerScript
 	}
 
 	/**
-	 * Move (s)css or js or image files of core templates which are left after deleting
+	 * Move core template (s)css or js or image files which are left after deleting
 	 * obsolete core files to the right place in media folder.
 	 *
 	 * @return  void

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -7621,6 +7621,8 @@ class JoomlaInstallerScript
 			}
 		}
 
+		$this->moveRemainingTemplateFiles();
+
 		foreach ($folders as $folder)
 		{
 			if ($folderExists = Folder::exists(JPATH_ROOT . $folder))
@@ -8435,6 +8437,43 @@ class JoomlaInstallerScript
 				{
 					// On Unix with both files: Delete the incorrectly cased file.
 					File::delete(JPATH_ROOT . $old);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Move (s)css or js or image files of core templates which are left after deleting
+	 * obsolete core files to the right place in media folder.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function moveRemainingTemplateFiles()
+	{
+		$folders = array(
+			'/administrator/templates/atum/css' => '/media/templates/administrator/atum/css',
+			'/administrator/templates/atum/images' => '/media/templates/administrator/atum/images',
+			'/administrator/templates/atum/js' => '/media/templates/administrator/atum/js',
+			'/administrator/templates/atum/scss' => '/media/templates/administrator/atum/scss',
+			'/templates/cassiopeia/css' => '/media/templates/site/cassiopeia/css',
+			'/templates/cassiopeia/images' => '/media/templates/site/cassiopeia/images',
+			'/templates/cassiopeia/js' => '/media/templates/site/cassiopeia/js',
+			'/templates/cassiopeia/scss' => '/media/templates/site/cassiopeia/scss',
+		);
+
+		foreach ($folders as $oldFolder => $newFolder)
+		{
+			if ($folderExists = Folder::exists(JPATH_ROOT . $oldFolder))
+			{
+				$oldPath = Path::clean(JPATH_ROOT . $oldFolder);
+				$newPath = Path::clean(JPATH_ROOT . $newFolder);
+
+				// Handle all files in this folder and all sub-folders
+				foreach (Folder::files($oldPath, '.*', true, true) as $file)
+				{
+					File::move($file, $newPath . substr($file, strlen($oldPath)));
 				}
 			}
 		}


### PR DESCRIPTION
Pull Request for https://github.com/joomla/joomla-cms/pull/35874 .

### Summary of Changes

This is how I would do it with the custom files.

I'd move them and not copy because this is open to any later possible change for the "Folder::delete" to delete folders on update only if they are not empty, like it was discussed a while ago e.g. with Brian T. in some other issue or PR in the CMS repo.

Feel free to change that if you thing copying is the safer way, as those files and folder will be deleted anyway at the end and for the intermediate time it might be safer to keep the old one e.g. due to cache issues or whatever.

I've also included a "js" folder for the Atum template even if the core doesn't have that, but a user might have created that for some custom JS.

Feel free to remove that if you don't like it.

And of course you can change other things too on my proposal, as at the end it is your PR where it goes in.

I haven't tested it yet but it should work 😄 