### PR TITLE
[CMS PR 36585] Move fixTemplateMode to preflight and fix it in 4.0.0-2018-03-05.sql for updates from 3.10

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -58,6 +58,9 @@ class JoomlaInstallerScript
 				{
 					$this->fromVersion = $manifestValues['version'];
 
+					// Ensure templates are moved to the correct mode
+					$this->fixTemplateMode();
+
 					return true;
 				}
 			}
@@ -99,9 +102,6 @@ class JoomlaInstallerScript
 		$this->deleteUnexistingFiles();
 		$this->updateManifestCaches();
 		$this->updateDatabase();
-
-		// Ensure templates are moved to the correct mode
-		$this->fixTemplateMode();
 		$this->updateAssets($installer);
 		$this->clearStatsCache();
 		$this->convertTablesToUtf8mb4(true);

--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2018-03-05.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2018-03-05.sql
@@ -19,6 +19,8 @@ INSERT INTO `#__extensions` (`name`, `type`, `element`, `folder`, `client_id`, `
 ('atum', 'template', 'atum', '', 1, 1, 1, 0, '{}', '{}', '', '', 0, '0000-00-00 00:00:00', 0, 0),
 ('cassiopeia', 'template', 'cassiopeia', '', 0, 1, 1, 0, '{}', '{}', '', '', 0, '0000-00-00 00:00:00', 0, 0);
 
+-- The following statement had to be modified for 4.1 by adding the `inheritable` and `parent` columns.
+-- See https://github.com/joomla/joomla-cms/pull/36585 .
 INSERT INTO `#__template_styles` (`template`, `client_id`, `home`, `title`, `inheritable`, `parent`, `params`) VALUES
 ('atum', 1, (CASE WHEN (SELECT b.`count` FROM (SELECT count(a.`id`) AS `count` FROM `#__template_styles` a WHERE a.`home` = '1' AND a.`client_id` = 1 AND a.`template` IN ('isis', 'hathor')) AS b) = 0 THEN '0' ELSE '1' END), 'atum - Default', 1, '', '{}'),
 ('cassiopeia', 0, (CASE WHEN (SELECT d.`count` FROM (SELECT count(c.`id`) AS `count` FROM `#__template_styles` c WHERE c.`home` = '1' AND c.`client_id` = 0 AND c.`template` IN ('protostar', 'beez3')) AS d) = 0 THEN '0' ELSE '1' END), 'cassiopeia - Default', 1, '', '{}');

--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2018-03-05.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2018-03-05.sql
@@ -19,9 +19,9 @@ INSERT INTO `#__extensions` (`name`, `type`, `element`, `folder`, `client_id`, `
 ('atum', 'template', 'atum', '', 1, 1, 1, 0, '{}', '{}', '', '', 0, '0000-00-00 00:00:00', 0, 0),
 ('cassiopeia', 'template', 'cassiopeia', '', 0, 1, 1, 0, '{}', '{}', '', '', 0, '0000-00-00 00:00:00', 0, 0);
 
-INSERT INTO `#__template_styles` (`template`, `client_id`, `home`, `title`, `params`) VALUES
-('atum', 1, (CASE WHEN (SELECT b.`count` FROM (SELECT count(a.`id`) AS `count` FROM `#__template_styles` a WHERE a.`home` = '1' AND a.`client_id` = 1 AND a.`template` IN ('isis', 'hathor')) AS b) = 0 THEN '0' ELSE '1' END), 'atum - Default', '{}'),
-('cassiopeia', 0, (CASE WHEN (SELECT d.`count` FROM (SELECT count(c.`id`) AS `count` FROM `#__template_styles` c WHERE c.`home` = '1' AND c.`client_id` = 0 AND c.`template` IN ('protostar', 'beez3')) AS d) = 0 THEN '0' ELSE '1' END), 'cassiopeia - Default', '{}');
+INSERT INTO `#__template_styles` (`template`, `client_id`, `home`, `title`, `inheritable`, `parent`, `params`) VALUES
+('atum', 1, (CASE WHEN (SELECT b.`count` FROM (SELECT count(a.`id`) AS `count` FROM `#__template_styles` a WHERE a.`home` = '1' AND a.`client_id` = 1 AND a.`template` IN ('isis', 'hathor')) AS b) = 0 THEN '0' ELSE '1' END), 'atum - Default', 1, '', '{}'),
+('cassiopeia', 0, (CASE WHEN (SELECT d.`count` FROM (SELECT count(c.`id`) AS `count` FROM `#__template_styles` c WHERE c.`home` = '1' AND c.`client_id` = 0 AND c.`template` IN ('protostar', 'beez3')) AS d) = 0 THEN '0' ELSE '1' END), 'cassiopeia - Default', 1, '', '{}');
 
 --
 -- Move mod_version to the right position for the atum template

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2018-03-05.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2018-03-05.sql
@@ -19,9 +19,9 @@ INSERT INTO "#__extensions" ("name", "type", "element", "folder", "client_id", "
 ('atum', 'template', 'atum', '', 1, 1, 1, 0, '{}', '{}', '', '', 0, '1970-01-01 00:00:00', 0, 0),
 ('cassiopeia', 'template', 'cassiopeia', '', 0, 1, 1, 0, '{}', '{}', '', '', 0, '1970-01-01 00:00:00', 0, 0);
 
-INSERT INTO "#__template_styles" ("template", "client_id", "home", "title", "params") VALUES
-('atum', 1, (CASE WHEN (SELECT b."count" FROM (SELECT count(a."id") AS "count" FROM "#__template_styles" a WHERE a."home" = '1' AND a."client_id" = 1 AND a."template" IN ('isis', 'hathor')) AS b) = 0 THEN '0' ELSE '1' END), 'atum - Default', '{}'),
-('cassiopeia', 0, (CASE WHEN (SELECT d."count" FROM (SELECT count(c."id") AS "count" FROM "#__template_styles" c WHERE c."home" = '1' AND c."client_id" = 0 AND c."template" IN ('protostar', 'beez3')) AS d) = 0 THEN '0' ELSE '1' END), 'cassiopeia - Default', '{}');
+INSERT INTO "#__template_styles" ("template", "client_id", "home", "title", "inheritable", "parent", "params") VALUES
+('atum', 1, (CASE WHEN (SELECT b."count" FROM (SELECT count(a."id") AS "count" FROM "#__template_styles" a WHERE a."home" = '1' AND a."client_id" = 1 AND a."template" IN ('isis', 'hathor')) AS b) = 0 THEN '0' ELSE '1' END), 'atum - Default', 1, '', '{}'),
+('cassiopeia', 0, (CASE WHEN (SELECT d."count" FROM (SELECT count(c."id") AS "count" FROM "#__template_styles" c WHERE c."home" = '1' AND c."client_id" = 0 AND c."template" IN ('protostar', 'beez3')) AS d) = 0 THEN '0' ELSE '1' END), 'cassiopeia - Default', 1, '', '{}');
 
 --
 -- Move mod_version to the right position for the atum template

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2018-03-05.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2018-03-05.sql
@@ -19,6 +19,8 @@ INSERT INTO "#__extensions" ("name", "type", "element", "folder", "client_id", "
 ('atum', 'template', 'atum', '', 1, 1, 1, 0, '{}', '{}', '', '', 0, '1970-01-01 00:00:00', 0, 0),
 ('cassiopeia', 'template', 'cassiopeia', '', 0, 1, 1, 0, '{}', '{}', '', '', 0, '1970-01-01 00:00:00', 0, 0);
 
+-- The following statement had to be modified for 4.1 by adding the "inheritable" and "parent" columns.
+-- See https://github.com/joomla/joomla-cms/pull/36585 .
 INSERT INTO "#__template_styles" ("template", "client_id", "home", "title", "inheritable", "parent", "params") VALUES
 ('atum', 1, (CASE WHEN (SELECT b."count" FROM (SELECT count(a."id") AS "count" FROM "#__template_styles" a WHERE a."home" = '1' AND a."client_id" = 1 AND a."template" IN ('isis', 'hathor')) AS b) = 0 THEN '0' ELSE '1' END), 'atum - Default', 1, '', '{}'),
 ('cassiopeia', 0, (CASE WHEN (SELECT d."count" FROM (SELECT count(c."id") AS "count" FROM "#__template_styles" c WHERE c."home" = '1' AND c."client_id" = 0 AND c."template" IN ('protostar', 'beez3')) AS d) = 0 THEN '0' ELSE '1' END), 'cassiopeia - Default', 1, '', '{}');


### PR DESCRIPTION
Pull Request for [Issue #](https://github.com/joomla/joomla-cms/pull/36585#issuecomment-1020136153) .

### Summary of Changes

See that comment.

Don't merge that yet, let's first discuss it in the CMS PR.

### Testing Instructions

Test both updating from 3.10 and from 4.0.x with having an SQL error in an update SQL script coming before "4.1.0-2021-11-28.sql".