### PR TITLE
[CMS PR 40626] Add migration on update

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -902,7 +902,6 @@ class JoomlaInstallerScript
         return true;
     }
 
-
     /**
      * Migrate TinyMCE editor plugin configuration
      *

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -946,10 +946,11 @@ class JoomlaInstallerScript
                  * "fontsizes"    -> "fontsize"
                  * "blockformats" -> "blocks"
                  * "formats"      -> "styles"
+                 * "template"     -> "jtemplate"
                  */
                 $params['configuration']['toolbars'][$setIdx]['menu'] = str_replace(
-                    ['fontformats', 'fontsizes', 'blockformats', 'formats'],
-                    ['fontfamily', 'fontsize', 'blocks', 'styles'],
+                    ['fontformats', 'fontsizes', 'blockformats', 'formats', 'template'],
+                    ['fontfamily', 'fontsize', 'blocks', 'styles', 'jtemplate'],
                     $toolbarConfig['menu']
                 );
             }
@@ -964,10 +965,11 @@ class JoomlaInstallerScript
                      * "fontsizeselect" -> "fontsize"
                      * "formatselect"   -> "blocks"
                      * "styleselect"    -> "styles"
+                     * "template"       -> "jtemplate"
                      */
                     $params['configuration']['toolbars'][$setIdx][$toolbarIdx] = str_replace(
-                        ['fontselect', 'fontsizeselect', 'formatselect', 'styleselect'],
-                        ['fontfamily', 'fontsize', 'blocks', 'styles'],
+                        ['fontselect', 'fontsizeselect', 'formatselect', 'styleselect', 'template'],
+                        ['fontfamily', 'fontsize', 'blocks', 'styles', 'jtemplate'],
                         $toolbarConfig[$toolbarIdx]
                     );
                 }

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -938,9 +938,9 @@ class JoomlaInstallerScript
         }
 
         // Each set has its own toolbar configuration
-        foreach ($params['configuration']['toolbars'] as $setIdx => $toolbar) {
+        foreach ($params['configuration']['toolbars'] as $setIdx => $toolbarConfig) {
             // Migrate menu items if there is a menu
-            if (isset($toolbar['menu'])) {
+            if (isset($toolbarConfig['menu'])) {
                 /**
                  * Replace array values with menu item names ("old name" -> "new name"):
                  * "fontformats"  -> "fontfamily"
@@ -951,14 +951,14 @@ class JoomlaInstallerScript
                 $params['configuration']['toolbars'][$setIdx]['menu'] = str_replace(
                     ['fontformats', 'fontsizes', 'blockformats', 'formats'],
                     ['fontfamily', 'fontsize', 'blocks', 'styles'],
-                    $toolbar['menu']
+                    $toolbarConfig['menu']
                 );
             }
 
             // There could be no toolbar at all, or only toolbar1, or both toolbar1 and toolbar2
             foreach (['toolbar1', 'toolbar2'] as $toolbarIdx) {
                 // Migrate toolbar buttons if that toolbar exists
-                if (isset($toolbar[$toolbarIdx])) {
+                if (isset($toolbarConfig[$toolbarIdx])) {
                     /**
                      * Replace array values with button names ("old name" -> "new name"):
                      * "fontselect"     -> "fontfamily"
@@ -969,7 +969,7 @@ class JoomlaInstallerScript
                     $params['configuration']['toolbars'][$setIdx][$toolbarIdx] = str_replace(
                         ['fontselect', 'fontsizeselect', 'formatselect', 'styleselect'],
                         ['fontfamily', 'fontsize', 'blocks', 'styles'],
-                        $toolbar[$toolbarIdx]
+                        $toolbarConfig[$toolbarIdx]
                     );
                 }
             }

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -942,15 +942,15 @@ class JoomlaInstallerScript
             if (isset($toolbarConfig['menu'])) {
                 /**
                  * Replace array values with menu item names ("old name" -> "new name"):
+                 * "blockformats" -> "blocks"
                  * "fontformats"  -> "fontfamily"
                  * "fontsizes"    -> "fontsize"
-                 * "blockformats" -> "blocks"
                  * "formats"      -> "styles"
                  * "template"     -> "jtemplate"
                  */
                 $params['configuration']['toolbars'][$setIdx]['menu'] = str_replace(
-                    ['fontformats', 'fontsizes', 'blockformats', 'formats', 'template'],
-                    ['fontfamily', 'fontsize', 'blocks', 'styles', 'jtemplate'],
+                    ['blockformats', 'fontformats', 'fontsizes', 'formats', 'template'],
+                    ['blocks', 'fontfamily', 'fontsize', 'styles', 'jtemplate'],
                     $toolbarConfig['menu']
                 );
             }

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -993,7 +993,7 @@ class JoomlaInstallerScript
         }
 
         return true;
-   }
+    }
 
     /**
      * Renames or removes incorrectly cased files.

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -895,7 +895,7 @@ class JoomlaInstallerScript
         }
 
         // Add here code which shall be executed only when updating from an older version than 5.0.0
-        if (!migrateTinymceConfiguration()) {
+        if (!$this->migrateTinymceConfiguration()) {
             return false;
         }
 

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -932,12 +932,22 @@ class JoomlaInstallerScript
 
         $params = json_decode($params, true);
 
+        // If there are no toolbars there is nothing to migrate
         if (!isset($params['configuration']['toolbars'])) {
             return true;
         }
 
+        // Each set has its own toolbar configuration
         foreach ($params['configuration']['toolbars'] as $setIdx => $toolbar) {
+            // Migrate menu items if there is a menu
             if (isset($toolbar['menu'])) {
+                /**
+                 * Replace array values with menu item names ("old name" -> "new name"):
+                 * "fontformats"  -> "fontfamily"
+                 * "fontsizes"    -> "fontsize"
+                 * "blockformats" -> "blocks"
+                 * "formats"      -> "styles"
+                 */
                 $params['configuration']['toolbars'][$setIdx]['menu'] = str_replace(
                     ['fontformats', 'fontsizes', 'blockformats', 'formats'],
                     ['fontfamily', 'fontsize', 'blocks', 'styles'],
@@ -945,8 +955,17 @@ class JoomlaInstallerScript
                 );
             }
 
+            // There could be no toolbar at all, or only toolbar1, or both toolbar1 and toolbar2
             foreach (['toolbar1', 'toolbar2'] as $toolbarIdx) {
+                // Migrate toolbar buttons if that toolbar exists
                 if (isset($toolbar[$toolbarIdx])) {
+                    /**
+                     * Replace array values with button names ("old name" -> "new name"):
+                     * "fontselect"     -> "fontfamily"
+                     * "fontsizeselect" -> "fontsize"
+                     * "formatselect"   -> "blocks"
+                     * "styleselect"    -> "styles"
+                     */
                     $params['configuration']['toolbars'][$setIdx][$toolbarIdx] = str_replace(
                         ['fontselect', 'fontsizeselect', 'formatselect', 'styleselect'],
                         ['fontfamily', 'fontsize', 'blocks', 'styles'],


### PR DESCRIPTION
Pull Request for https://github.com/joomla/joomla-cms/pull/40626 .

### Summary of Changes

This PR adds the migration of the TinyMCE editor plugin's parameters (column `params` of the record for that plugin in table `#__extensions`) when updating the CMS from 4.4 to 5 and so updating TinyMCE from 5 to 6.

@dgrammatiko Should we add this to your PR, or should I create a separate one in the CMS repo? And could you advise on that plugin thing? I see we have also external plugins, and maybe we should not touch these?